### PR TITLE
Update readme file

### DIFF
--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -78,10 +78,15 @@ pub run build_runner build
 For Flutter the command is different though:
 
 ```bash
-flutter packages pub run build_runner watch --delete-conflicting-outputs
+flutter packages pub run build_runner build
 ```
-The argument --delete-conficting-outputs will let the command delete the .g.dart generated file, before re-creating it. Without that parameter running the command will fail because the generated file already exists.
 
+On first attempt to run this command you might encounter a conflict error. If that is the case please add the --delete-conflicting-outputs argument to your command like so:
+
+```bash
+flutter packages pub run build_runner build --delete-conflicting-outputs
+```
+This additional argument will let the command that it can delete, and create again, the .g.dart file if need be.
 
 
 

--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -80,7 +80,8 @@ For Flutter the command is different though:
 ```bash
 flutter packages pub run build_runner watch --delete-conflicting-outputs
 ```
-The argument --delete-conficting-outputs will let the command delete the .g.dart generated file, before re-creating it. Without that parameter running the command will fail because the generated file already exists
+The argument --delete-conficting-outputs will let the command delete the .g.dart generated file, before re-creating it. Without that parameter running the command will fail because the generated file already exists.
+
 
 
 

--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -78,8 +78,11 @@ pub run build_runner build
 For Flutter the command is different though:
 
 ```bash
-flutter packages pub run build_runner build
+flutter packages pub run build_runner watch --delete-conflicting-outputs
 ```
+The argument --delete-conficting-outputs will let the command delete the .g.dart generated file, before re-creating it. Without that parameter running the command will fail because the generated file already exists
+
+
 
 You can also use the `watch` command instead of `build`. This will generate your file when it's saved.
 


### PR DESCRIPTION
On first attempt to run the flutter packages pub run build_runner build command, I ended up having a couple of errors regarding "conflicting outputs".

After digging up a little, I found out that the command could not modify the file for some reason.

Adding an additional argument to the command, let it delete and re-create the file if need be.

After that initial run I could run the initial command of the documentation without any issue.

It's minor, but might help