### PR TITLE
Update dependencies for kiwi_generator

### DIFF
--- a/kiwi_generator/pubspec.yaml
+++ b/kiwi_generator/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:  
-  analyzer: '>= 0.32.4 <0.34.0'
-  build: '>=0.12.6 <1.1.0'
+  analyzer: '>= 0.32.4 <0.35.0'
+  build: '>=0.12.6 <1.2.0'
   build_config: ^0.3.1
   code_builder: ^3.1.3
   dart_style: '>= 1.0.0 <1.3.0'


### PR DESCRIPTION
The dependencies `analyzer` and `build`, which `kiwi_generator` depends on, have been updated. I've thus increased the maximum version for those. The tests still run, so I assume that this didn't break anything. It also preserves backwards-compatibility as the old versions of the dependencies can still be used.