### PR TITLE
poc: [For Evaluation] example implementation of assisted injection

### DIFF
--- a/packages/kiwi/lib/src/kiwi_container.dart
+++ b/packages/kiwi/lib/src/kiwi_container.dart
@@ -11,6 +11,8 @@ typedef _ProviderName = String;
 /// Signature for the generic provider value.
 typedef _ProviderValue = Map<Type, _Provider<Object>>;
 
+typedef AssistedInjector<S, P> = S Function(P);
+
 /// A simple service container.
 class KiwiContainer {
   /// Creates a scoped container.
@@ -121,12 +123,12 @@ class KiwiContainer {
   /// If [name] is set, the factory will be registered under this name.
   /// To retrieve the same factory, the same name should be provided
   /// to [KiwiContainer.resolve].
-  void registerAssistedFactory<S>(
-    FactoryBuilder<S Function(Map<String, dynamic>)> factory, {
+
+  void registerAssistedFactory<S, P>(
+    FactoryBuilder<AssistedInjector<S, P>> factory, {
     String? name,
   }) {
-    _setProvider(
-        name, _Provider<S Function(Map<String, dynamic>)>.factory(factory));
+    _setProvider(name, _Provider<AssistedInjector<S, P>>.factory(factory));
   }
 
   /// Registers a factory that will be called only only when

--- a/packages/kiwi/lib/src/kiwi_container.dart
+++ b/packages/kiwi/lib/src/kiwi_container.dart
@@ -114,6 +114,21 @@ class KiwiContainer {
     _setProvider(name, _Provider<S>.factory(factory));
   }
 
+  /// Registers a factory with assistend injection into the container.
+  ///
+  /// A factory returning Function that returns an object of type [S] can be registered.
+  ///
+  /// If [name] is set, the factory will be registered under this name.
+  /// To retrieve the same factory, the same name should be provided
+  /// to [KiwiContainer.resolve].
+  void registerAssistedFactory<S>(
+    FactoryBuilder<S Function(Map<String, dynamic>)> factory, {
+    String? name,
+  }) {
+    _setProvider(
+        name, _Provider<S Function(Map<String, dynamic>)>.factory(factory));
+  }
+
   /// Registers a factory that will be called only only when
   /// accessing it for the first time, into the container.
   ///

--- a/packages/kiwi/pubspec.yaml
+++ b/packages/kiwi/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gbtb16/kiwi/tree/master/packages/kiwi
 issue_tracker: https://github.com/gbtb16/kiwi/issues
 
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: ">=3.0.0"
 
 dependencies:
   meta: ^1.8.0

--- a/packages/kiwi/test/kiwi_test.dart
+++ b/packages/kiwi/test/kiwi_test.dart
@@ -100,6 +100,10 @@ void main() {
       container.registerFactory<Character>(
           (c) => const Sith('Anakin', 'Skywalker', 'DarthVader'),
           name: 'named');
+      container.registerAssistedFactory<Sith>((c) {
+        return (Map<String, dynamic> args) =>
+            Sith('Sheev', 'Palpatine', args['id']);
+      });
 
       expect(container.resolve<int>(), 5);
       expect(container.resolve<Sith>(),
@@ -108,6 +112,13 @@ void main() {
           const Character('Anakin', 'Skywalker'));
       expect(container.resolve<Character>('named'),
           const Sith('Anakin', 'Skywalker', 'DarthVader'));
+
+      final Sith sith =
+          container.resolve<Sith Function(Map<String, dynamic>)>()(
+              {"id": "DarthSidious"});
+      expect(sith.id, equals('DarthSidious'));
+      expect(sith.firstName, equals('Sheev'));
+      expect(sith.lastName, equals('Palpatine'));
     });
 
     test('builders should always be created', () {

--- a/packages/kiwi/test/kiwi_test.dart
+++ b/packages/kiwi/test/kiwi_test.dart
@@ -100,9 +100,10 @@ void main() {
       container.registerFactory<Character>(
           (c) => const Sith('Anakin', 'Skywalker', 'DarthVader'),
           name: 'named');
-      container.registerAssistedFactory<Sith>((c) {
-        return (Map<String, dynamic> args) =>
-            Sith('Sheev', 'Palpatine', args['id']);
+
+      container.registerAssistedFactory<Sith, SithAssistedParameters>((c) {
+        return (SithAssistedParameters args) =>
+            Sith('Sheev', 'Palpatine', args.id);
       });
 
       expect(container.resolve<int>(), 5);
@@ -114,8 +115,9 @@ void main() {
           const Sith('Anakin', 'Skywalker', 'DarthVader'));
 
       final Sith sith =
-          container.resolve<Sith Function(Map<String, dynamic>)>()(
-              {"id": "DarthSidious"});
+          container.resolve<AssistedInjector<Sith, SithAssistedParameters>>()(
+              (id: 'DarthSidious'));
+
       expect(sith.id, equals('DarthSidious'));
       expect(sith.firstName, equals('Sheev'));
       expect(sith.lastName, equals('Palpatine'));
@@ -509,6 +511,8 @@ class Character {
   final String firstName;
   final String lastName;
 }
+
+typedef SithAssistedParameters = ({String id});
 
 class Sith extends Character {
   const Sith(


### PR DESCRIPTION
Hi Gabriel,
Kiwi is a very simple and beautiful DI framework, congrats!

I think a missing key feature is assisted injection, so here i've put together an example implementation for you to evaluate.
Another option would be using Records instead of Maps for the arguments, but it will require the bump of the SDK version to at least > 3.0.0

Let me know how you feel about it and if it makes sense for you.



